### PR TITLE
Modifica consulta y select de materiales

### DIFF
--- a/cotizar/front.php
+++ b/cotizar/front.php
@@ -46,17 +46,13 @@ $materiales = get_materiales($conn);
 					<label for="material">Material</label>
 				</div>
 				<div class="col-12 col-lg-3 mb-lg-3">
-					<select class="form-control" name="material" id="material">
-						<?php foreach($materiales as $clave => $lista): ?>
-							<optgroup label="<?php echo htmlspecialchars($clave); ?>">
-								<?php foreach($lista as $m): ?>
-									<option value="<?php echo $m['clave']; ?>">
-										<?php echo htmlspecialchars($m['descripcion']) . " - $" . number_format($m['precio'], 2) . "/m²"; ?>
-									</option>
-								<?php endforeach; ?>
-							</optgroup>
-						<?php endforeach; ?>
-					</select>
+        <select class="form-control" name="material" id="material">
+            <?php foreach($materiales as $m): ?>
+                <option value="<?php echo $m['clave']; ?>">
+                    <?php echo htmlspecialchars($m['clave']) . " - $" . number_format($m['precio_m2'], 2) . "/m²"; ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
 				</div>
 				<div class="col-12 col-lg-1 mb-lg-3">
 					<label for="cantidad">Cantidad</label>

--- a/cotizar/funciones.php
+++ b/cotizar/funciones.php
@@ -12,12 +12,15 @@ function get_armados(mysqli $conn){
 }
 
 function get_materiales(mysqli $conn){
-    $sql = "SELECT clave, descripcion, tipo, precio FROM material ORDER BY CASE WHEN tipo='metro' THEN 0 ELSE 1 END, precio";
+    $sql = "SELECT clave, tipo, MIN(CASE WHEN tipo='lamina' THEN precio * 10 /(largo_max * ancho_max) ELSE precio END) AS precio_m2
+            FROM material
+            GROUP BY clave, tipo
+            ORDER BY CASE WHEN tipo='metro' THEN 0 ELSE 1 END, precio_m2";
     $res = mysqli_query($conn, $sql);
     $materiales = [];
     if ($res) {
         while ($row = mysqli_fetch_assoc($res)) {
-            $materiales[$row['clave']][] = $row;
+            $materiales[] = $row;
         }
     }
     return $materiales;


### PR DESCRIPTION
## Summary
- agrupar materiales por clave en la consulta
- calcular precio por m² para materiales tipo lámina
- simplificar el `<select>` de materiales en el formulario

## Testing
- `php -l cotizar/funciones.php`
- `php -l cotizar/front.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68758d2acf4c8326a1a2352ef6514b68