### PR TITLE
Implement advanced quote options

### DIFF
--- a/cotizar/back.php
+++ b/cotizar/back.php
@@ -1,23 +1,97 @@
 <?php
-/*
- * Aqui se procesan los datos enviados en el formulario front.php
- * Se definen todas las variables esperadas con un valor por
- * defecto en caso de que no se reciban desde el formulario.
- */
+require_once 'funciones.php';
 
-// Medidas de la caja en milimetros
-$largo    = isset($_POST['largo'])    ? (float)$_POST['largo']    : 0.0;
-$ancho    = isset($_POST['ancho'])    ? (float)$_POST['ancho']    : 0.0;
-$alto     = isset($_POST['alto'])     ? (float)$_POST['alto']     : 0.0;
+$resultados = [];
 
-// Tipo de armado de la caja
-$armado   = isset($_POST['armado'])   ? trim($_POST['armado'])    : '';
+if (isset($_GET['cotizar'], $_GET['largo'], $_GET['ancho'], $_GET['alto'], $_GET['armado'], $_GET['material'])) {
+    $largo = (float)$_GET['largo'];
+    $ancho = (float)$_GET['ancho'];
+    $alto = (float)$_GET['alto'];
+    $armado = (int)$_GET['armado'];
+    $material = $_GET['material'];
 
-// Material seleccionado
-$material = isset($_POST['material']) ? trim($_POST['material']) : '';
+    $valores = get_valores($conn);
+    $procesos_base = get_procesos($conn);
 
-// Cantidad de piezas solicitadas
-$cantidad = isset($_POST['cantidad']) ? (int)$_POST['cantidad']  : 0;
+    foreach ($procesos_base as $id => &$proc) {
+        $k = 'proc_' . $id;
+        if (isset($_GET[$k]) && $_GET[$k] !== '') {
+            $proc['precio'] = (float)$_GET[$k];
+        }
+    }
 
-// A partir de aqui se podra continuar con el proceso de cotizacion
+    if (isset($_GET['suaje']) && $_GET['suaje'] !== '') {
+        $valores['suaje'] = (float)$_GET['suaje'];
+    }
+    if (isset($_GET['utilidad']) && $_GET['utilidad'] !== '') {
+        $valores['utilidad'] = (float)$_GET['utilidad'];
+    }
+    if (isset($_GET['merma']) && $_GET['merma'] !== '') {
+        $valores['merma'] = (float)$_GET['merma'];
+    }
+
+    $datos = obtener_datos_caja($armado, $largo, $ancho, $alto);
+    $material_info = get_material_info($conn, $material);
+
+    if ($material_info) {
+        $m2_total = 0.0;
+        $cm_suaje_total = 0.0;
+        $sustrato_resumen = [];
+        foreach ($datos['largo_lamina'] as $i => $ll) {
+            $al = $datos['ancho_lamina'][$i];
+            $m2_total += ($ll/100) * ($al/100) * 1000;
+            $cm_suaje_total += $datos['cm_suaje'][$i] * 1000;
+            $nombre = $datos['nombre'][$i] ?? ('Parte ' . ($i+1));
+            $sustrato_resumen[] = $nombre . ': ' . round($ll,2) . ' x ' . round($al,2) . ' cm';
+        }
+        $m2_total *= (1 + $valores['merma']/100);
+        $costo_material = $m2_total * $material_info['precio_m2'];
+        $costo_suaje = $cm_suaje_total * $valores['suaje'];
+        $costo_suajado = costo_suajado($conn, $costo_suaje);
+
+        $procesos_armado = get_procesos_armado($conn, $armado);
+        $costo_procesos = 0.0;
+        foreach ($procesos_armado as $p) {
+            if ($p['id'] == 5) {
+                $costo_procesos += $costo_suajado;
+            } else {
+                $costo_procesos += $procesos_base[$p['id']]['precio'];
+            }
+        }
+
+        $costo_millar = ($costo_procesos + $costo_material) * (1 + $valores['utilidad']/100);
+        $iva = $valores['iva'];
+
+        $factores = [1=>3,25=>1.3,50=>1.22,100=>1.16,200=>1.11,500=>1.05,1000=>1];
+        $tabla = [];
+        foreach ($factores as $vol => $fac) {
+            $costo_vol = $costo_millar * $fac;
+            $caja_sin = $costo_vol / ($vol*1000);
+            $caja_con = $caja_sin * (1 + $iva/100);
+            $suaje_sin = $costo_suaje / ($vol*1000);
+            $suaje_con = $suaje_sin * (1 + $iva/100);
+            $tot_sin = $caja_sin + $suaje_sin;
+            $tot_con = $tot_sin * (1 + $iva/100);
+            $tabla[$vol] = [
+                'caja_sin_iva'=>$caja_sin,
+                'caja_con_iva'=>$caja_con,
+                'suaje_sin_iva'=>$suaje_sin,
+                'suaje_con_iva'=>$suaje_con,
+                'total_sin_iva'=>$tot_sin,
+                'total_con_iva'=>$tot_con
+            ];
+        }
+
+        $resultados = [
+            'tabla'=>$tabla,
+            'sustrato'=>$sustrato_resumen,
+            'precio_suaje'=>$costo_suaje,
+            'resumen'=>[
+                'armado'=>get_armado_nombre($conn,$armado),
+                'medidas'=>$largo.' x '.$ancho.' x '.$alto.' cm',
+                'material'=>$material_info['descripcion']
+            ]
+        ];
+    }
+}
 ?>

--- a/cotizar/front.php
+++ b/cotizar/front.php
@@ -2,6 +2,8 @@
 require_once 'funciones.php';
 $armados = get_armados($conn);
 $materiales = get_materiales($conn);
+$procesos  = get_procesos($conn);
+$valores   = get_valores($conn);
 $similares = [];
 if (isset($_GET['largo'], $_GET['ancho'], $_GET['alto'])) {
     $l = (float)$_GET['largo'];
@@ -17,7 +19,8 @@ if (isset($_GET['largo'], $_GET['ancho'], $_GET['alto'])) {
 				<h5>Caja</h5>
 			</div>
 		</div>
-		<form class="form" method="get">
+                <form class="form" method="get">
+                        <input type="hidden" name="cotizar" value="1">
 			<div class="row">
 				<div class="col-12 col-lg-1 mb-lg-3">
 					<label for="largo" class="form-label">Largo</label>
@@ -59,21 +62,109 @@ if (isset($_GET['largo'], $_GET['ancho'], $_GET['alto'])) {
 			                    <?php echo htmlspecialchars($m['descripcion']) . " - $" . number_format($m['precio_m2'], 2) . "/m²"; ?>
 			                </option>
 			            <?php endforeach; ?>
-			        </select>
-				</div>
-				<div class="col-12 col-lg-1 mb-lg-3">
-					<label for="cantidad">Cantidad</label>
-				</div>
-                                <div class="col-12 col-lg-3 mb-lg-3">
-                                        <input class="form-control" type="number" name="cantidad" placeholder="1000" value="<?php echo isset($_GET['cantidad']) ? htmlspecialchars($_GET['cantidad']) : '' ?>" required>
+                                </select>
                                 </div>
                         </div>
-			<div class="row">
-				<div class="col-12 text-center">
-					<button type="submit" class="btn btn-primary">Cotizar</button>
-				</div>
-			</div>
+                        <div class="row">
+                                <div class="col-12 text-center">
+                                        <button type="submit" class="btn btn-primary me-2">Cotizar</button>
+                                        <button type="button" class="btn btn-secondary" data-bs-toggle="collapse" data-bs-target="#opciones_avanzadas">Avanzado</button>
+                                </div>
+                        </div>
+                        <div class="collapse mt-3" id="opciones_avanzadas">
+                                <div class="card card-body">
+                                        <div class="row g-3">
+                                                <?php foreach($procesos as $p): ?>
+                                                <div class="col-6 col-lg-3">
+                                                        <label class="form-label" for="proc_<?php echo $p['id']; ?>"><?php echo htmlspecialchars($p['nombre']); ?></label>
+                                                        <input class="form-control" type="number" step="0.01" name="proc_<?php echo $p['id']; ?>" id="proc_<?php echo $p['id']; ?>" value="<?php echo number_format($p['precio'],2,'.',''); ?>">
+                                                </div>
+                                                <?php endforeach; ?>
+                                                <div class="col-6 col-lg-3">
+                                                        <label class="form-label" for="suaje">Suaje cm</label>
+                                                        <input class="form-control" type="number" step="0.01" name="suaje" id="suaje" value="<?php echo number_format($valores['suaje'],2,'.',''); ?>">
+                                                </div>
+                                                <div class="col-6 col-lg-3">
+                                                        <label class="form-label" for="utilidad">Utilidad %</label>
+                                                        <input class="form-control" type="number" step="0.01" name="utilidad" id="utilidad" value="<?php echo number_format($valores['utilidad'],2,'.',''); ?>">
+                                                </div>
+                                                <div class="col-6 col-lg-3">
+                                                        <label class="form-label" for="merma">Merma %</label>
+                                                        <input class="form-control" type="number" step="0.01" name="merma" id="merma" value="<?php echo number_format($valores['merma'],2,'.',''); ?>">
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
                 </form>
+                <?php
+                if (isset($_GET['cotizar'])) {
+                        require 'back.php';
+                        if (!empty($resultados)) {
+                ?>
+                <div class="mt-3">
+                        <p><strong>Armado:</strong> <?php echo htmlspecialchars($resultados['resumen']['armado']); ?><br>
+                        <strong>Medidas:</strong> <?php echo htmlspecialchars($resultados['resumen']['medidas']); ?><br>
+                        <strong>Material:</strong> <?php echo htmlspecialchars($resultados['resumen']['material']); ?></p>
+                </div>
+                <div class="table-responsive">
+                        <table class="table table-sm">
+                                <thead>
+                                        <tr>
+                                                <th></th>
+                                                <?php foreach($resultados['tabla'] as $vol => $vals): ?>
+                                                <th><?php echo $vol; ?>k</th>
+                                                <?php endforeach; ?>
+                                        </tr>
+                                </thead>
+                                <tbody>
+                                        <tr>
+                                                <th>Precio caja sin IVA</th>
+                                                <?php foreach($resultados['tabla'] as $vals): ?>
+                                                <td>$<?php echo number_format($vals['caja_sin_iva'],2); ?></td>
+                                                <?php endforeach; ?>
+                                        </tr>
+                                        <tr>
+                                                <th>Precio caja con IVA</th>
+                                                <?php foreach($resultados['tabla'] as $vals): ?>
+                                                <td>$<?php echo number_format($vals['caja_con_iva'],2); ?></td>
+                                                <?php endforeach; ?>
+                                        </tr>
+                                        <tr>
+                                                <th>Suaje diluido sin IVA</th>
+                                                <?php foreach($resultados['tabla'] as $vals): ?>
+                                                <td>$<?php echo number_format($vals['suaje_sin_iva'],2); ?></td>
+                                                <?php endforeach; ?>
+                                        </tr>
+                                        <tr>
+                                                <th>Suaje diluido con IVA</th>
+                                                <?php foreach($resultados['tabla'] as $vals): ?>
+                                                <td>$<?php echo number_format($vals['suaje_con_iva'],2); ?></td>
+                                                <?php endforeach; ?>
+                                        </tr>
+                                        <tr>
+                                                <th>Caja + suaje sin IVA</th>
+                                                <?php foreach($resultados['tabla'] as $vals): ?>
+                                                <td>$<?php echo number_format($vals['total_sin_iva'],2); ?></td>
+                                                <?php endforeach; ?>
+                                        </tr>
+                                        <tr>
+                                                <th>Caja + suaje con IVA</th>
+                                                <?php foreach($resultados['tabla'] as $vals): ?>
+                                                <td>$<?php echo number_format($vals['total_con_iva'],2); ?></td>
+                                                <?php endforeach; ?>
+                                        </tr>
+                                </tbody>
+                        </table>
+                </div>
+                <p class="mt-3 mb-0"><strong>Medidas del sustrato:</strong></p>
+                <ul class="mb-0">
+                        <?php foreach($resultados['sustrato'] as $s): ?>
+                        <li><?php echo htmlspecialchars($s); ?></li>
+                        <?php endforeach; ?>
+                </ul>
+                <p class="mt-2"><strong>Precio del suaje:</strong> $<?php echo number_format($resultados['precio_suaje'],2); ?></p>
+                <?php } }
+                ?>
         </div>
 </div>
 <div class="modal fade" id="armadoModal" tabindex="-1" aria-labelledby="armadoModalLabel" aria-hidden="true">

--- a/cotizar/funciones.php
+++ b/cotizar/funciones.php
@@ -255,4 +255,80 @@ function obtener_datos_caja($armado, $largo_caja, $ancho_caja, $alto_caja){
             break;
     }
 }
+
+function get_procesos(mysqli $conn): array {
+    $res = mysqli_query($conn, "SELECT id, nombre, precio FROM procesos");
+    $procesos = [];
+    if ($res) {
+        while ($row = mysqli_fetch_assoc($res)) {
+            $procesos[$row['id']] = $row;
+        }
+    }
+    return $procesos;
+}
+
+function get_procesos_armado(mysqli $conn, int $armado): array {
+    $stmt = mysqli_prepare($conn, "SELECT p.id, p.nombre FROM armado_procesos ap JOIN procesos p ON ap.id_proceso=p.id WHERE ap.id_armado=?");
+    $procesos = [];
+    if ($stmt) {
+        mysqli_stmt_bind_param($stmt, 'i', $armado);
+        mysqli_stmt_execute($stmt);
+        $res = mysqli_stmt_get_result($stmt);
+        while ($row = mysqli_fetch_assoc($res)) {
+            $procesos[] = $row;
+        }
+        mysqli_stmt_close($stmt);
+    }
+    return $procesos;
+}
+
+function get_valores(mysqli $conn): array {
+    $res = mysqli_query($conn, "SELECT nombre, precio FROM valores");
+    $valores = [];
+    if ($res) {
+        while ($row = mysqli_fetch_assoc($res)) {
+            $valores[strtolower($row['nombre'])] = (float)$row['precio'];
+        }
+    }
+    return $valores;
+}
+
+function get_material_info(mysqli $conn, string $clave): ?array {
+    $stmt = mysqli_prepare($conn, "SELECT tipo, descripcion, CASE WHEN tipo='lamina' THEN precio*10/(largo_max*ancho_max) ELSE precio END AS precio_m2 FROM material WHERE clave=? ORDER BY precio_m2 ASC LIMIT 1");
+    if ($stmt) {
+        mysqli_stmt_bind_param($stmt, 's', $clave);
+        mysqli_stmt_execute($stmt);
+        $res = mysqli_stmt_get_result($stmt);
+        $row = mysqli_fetch_assoc($res);
+        mysqli_stmt_close($stmt);
+        if ($row) return $row;
+    }
+    return null;
+}
+
+function get_armado_nombre(mysqli $conn, int $id): string {
+    $stmt = mysqli_prepare($conn, "SELECT nombre FROM armado WHERE id=?");
+    if ($stmt) {
+        mysqli_stmt_bind_param($stmt, 'i', $id);
+        mysqli_stmt_execute($stmt);
+        $res = mysqli_stmt_get_result($stmt);
+        $row = mysqli_fetch_assoc($res);
+        mysqli_stmt_close($stmt);
+        if ($row) return $row['nombre'];
+    }
+    return '';
+}
+
+function costo_suajado(mysqli $conn, float $precio_suaje): float {
+    $stmt = mysqli_prepare($conn, "SELECT precio FROM rangos_suajado WHERE ? BETWEEN rango_inf AND rango_sup LIMIT 1");
+    if ($stmt) {
+        mysqli_stmt_bind_param($stmt, 'd', $precio_suaje);
+        mysqli_stmt_execute($stmt);
+        $res = mysqli_stmt_get_result($stmt);
+        $row = mysqli_fetch_assoc($res);
+        mysqli_stmt_close($stmt);
+        if ($row) return (float)$row['precio'];
+    }
+    return 0.0;
+}
 ?>


### PR DESCRIPTION
## Summary
- remove quantity field from quote form and add "Avanzado" collapse section
- calculate quotes in `back.php` using DB values
- expose helpers in `funciones.php`
- show quote summary and price table in `front.php`

## Testing
- `php -l cotizar/front.php`
- `php -l cotizar/funciones.php`
- `php -l cotizar/back.php`
- `find . -name '*.php' | xargs -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68884fef49dc8326a77879cd454fa76a