### PR TITLE
Preserve select values in quote form

### DIFF
--- a/cotizar/front.php
+++ b/cotizar/front.php
@@ -110,7 +110,7 @@ if (isset($_GET['largo'], $_GET['ancho'], $_GET['alto'])) {
 				<div class="col-12 col-lg-3 mb-lg-3">
                                         <select class="form-control" name="armado" id="armado">
                                                 <?php foreach($armados as $arm): ?>
-                                                        <option value="<?php echo $arm['id']; ?>" <?php if($arm['id']==1) echo 'selected'; ?>>
+                                                        <option value="<?php echo $arm['id']; ?>" <?php echo ($arm['id'] == $selected_armado) ? 'selected' : ''; ?>>
                                                                 <?php echo htmlspecialchars($arm['nombre']); ?>
                                                         </option>
                                                 <?php endforeach; ?>
@@ -120,12 +120,12 @@ if (isset($_GET['largo'], $_GET['ancho'], $_GET['alto'])) {
 					<label for="material">Material</label>
 				</div>
 				<div class="col-12 col-lg-3 mb-lg-3">
-			        <select class="form-control" name="material" id="material">
-			            <?php foreach($materiales as $m): ?>
-			                <option value="<?php echo $m['clave']; ?>">
-			                    <?php echo htmlspecialchars($m['descripcion']) . " - $" . number_format($m['precio_m2'], 2) . "/m²"; ?>
-			                </option>
-			            <?php endforeach; ?>
+                                <select class="form-control" name="material" id="material">
+                                    <?php foreach($materiales as $m): ?>
+                                        <option value="<?php echo $m['clave']; ?>" <?php echo ($m['clave'] == $selected_material) ? 'selected' : ''; ?>>
+                                            <?php echo htmlspecialchars($m['descripcion']) . " - $" . number_format($m['precio_m2'], 2) . "/m²"; ?>
+                                        </option>
+                                    <?php endforeach; ?>
                                 </select>
                                 </div>
                         </div>


### PR DESCRIPTION
## Summary
- keep selected values for Armado and Material after quoting

## Testing
- `php -l cotizar/front.php`


------
https://chatgpt.com/codex/tasks/task_e_68898b9a71f48326ad329f8c57f03dc2