### PR TITLE
fix: prevent deleting all sales and redirect warning

### DIFF
--- a/ventas/eliminar.php
+++ b/ventas/eliminar.php
@@ -1,0 +1,24 @@
+<?php
+session_start();
+require_once __DIR__ . '/../conn.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: ../login.php');
+    exit;
+}
+
+$vendedor_id = (int)$_SESSION['usuario_id'];
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+
+if ($id > 0) {
+    $stmt = mysqli_prepare($conn, 'DELETE FROM ventas WHERE id=? AND vendedor=? LIMIT 1');
+    if ($stmt) {
+        mysqli_stmt_bind_param($stmt, 'ii', $id, $vendedor_id);
+        mysqli_stmt_execute($stmt);
+        mysqli_stmt_close($stmt);
+    }
+}
+
+header('Location: ../index.php?action=registro_ventas');
+exit;
+?>

--- a/ventas/ventas.php
+++ b/ventas/ventas.php
@@ -3,19 +3,6 @@
 
 $vendedor_id = $_SESSION['usuario_id'] ?? 0;
 
-// Eliminar registro
-if (isset($_GET['eliminar'])) {
-    $id_eliminar = (int)$_GET['eliminar'];
-    $stmt = mysqli_prepare($conn, "DELETE FROM ventas WHERE id=? AND vendedor=?");
-    if ($stmt) {
-        mysqli_stmt_bind_param($stmt, 'ii', $id_eliminar, $vendedor_id);
-        mysqli_stmt_execute($stmt);
-        mysqli_stmt_close($stmt);
-    }
-    header('Location: index.php?action=registro_ventas');
-    exit;
-}
-
 // Procesar envio del formulario
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $fecha = $_POST['fecha'] ?? date('Y-m-d');
@@ -143,7 +130,7 @@ if ($stmt) {
                             <?php echo $v['monto_suaje'] !== null ? '$'.number_format($v['monto_suaje'],2) : '-'; ?>
                         </td>
                         <td>
-                            <a href="index.php?action=registro_ventas&eliminar=<?php echo $v['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar venta?');"><i class="fa fa-trash"></i></a>
+                            <a href="ventas/eliminar.php?id=<?php echo $v['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar venta?');"><i class="fa fa-trash"></i></a>
                         </td>
                     </tr>
                     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- extract sale deletion into standalone handler to avoid mass deletions and header errors
- remove inline delete logic from sales view and link to new handler

## Testing
- `php -l ventas/eliminar.php`
- `php -l ventas/ventas.php`


------
https://chatgpt.com/codex/tasks/task_e_688b82c1ae848326bac1a10e170e94bc