### PR TITLE
Add option to optimize box price without distributing die cost

### DIFF
--- a/cotizar/funciones.php
+++ b/cotizar/funciones.php
@@ -624,6 +624,7 @@ function cotizar_suaje_multiple(mysqli $conn, int $armado, float $largo, float $
     foreach($datos_caja['cm_suaje'] as $c){
         $cm_base += $c;
     }
+    $solo_caja = !empty($opciones['solo_caja']);
     $volumenes = [1000,2000,3000,4000,5000,10000];
     $resultados = [];
     foreach($volumenes as $vol){
@@ -664,10 +665,11 @@ function cotizar_suaje_multiple(mysqli $conn, int $armado, float $largo, float $
             $iva = $cot['iva'];
             $costo_total_sin_iva = $base_total * (1 + $utilidad/100);
             $precio_caja_sin_iva = $costo_total_sin_iva / $vol;
-            $precio_suaje_pieza = $precio_suaje / $vol;
+            $precio_suaje_pieza = $solo_caja ? 0 : $precio_suaje / $vol;
             $precio_total_sin_iva = $precio_caja_sin_iva + $precio_suaje_pieza;
             $precio_total_con_iva = $precio_total_sin_iva * (1 + $iva/100);
-            if($mejor === null || $precio_total_sin_iva < $mejor['precio_total_sin_iva']){
+            $criterio = $solo_caja ? $precio_caja_sin_iva : $precio_total_sin_iva;
+            if($mejor === null || $criterio < $mejor['criterio']){
                 $mejor = [
                     'piezas_por_golpe' => $m,
                     'cm_suaje_total' => $cm_total,
@@ -679,10 +681,13 @@ function cotizar_suaje_multiple(mysqli $conn, int $armado, float $largo, float $
                     'precio_suaje_pieza' => $precio_suaje_pieza,
                     'precio_total_sin_iva' => $precio_total_sin_iva,
                     'precio_total_con_iva' => $precio_total_con_iva,
+                    'precio_suaje_total' => $precio_suaje,
+                    'criterio' => $criterio,
                 ];
             }
         }
         if($mejor){
+            unset($mejor['criterio']);
             $resultados[$vol] = $mejor;
         }
     }


### PR DESCRIPTION
## Summary
- allow choosing between optimizing total price (box + die) or box price alone
- adjust `cotizar_suaje_multiple` to skip distributing die cost when optimizing box price
- display die cost separately in volume table and details

## Testing
- `php -l cotizar/funciones.php`
- `php -l cotizar/front.php`


------
https://chatgpt.com/codex/tasks/task_e_68912bfac2d88326bbe3bb2f58b47336